### PR TITLE
fix FluentBitConfig controller generates redundant config files

### DIFF
--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -95,8 +95,8 @@ func (r *FluentBitConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		// Create or update the corresponding Secret
 		sec := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Name,
-				Namespace: req.Namespace,
+				Name:      cfg.Name,
+				Namespace: cfg.Namespace,
 			},
 			Data: map[string][]byte{"fluent-bit.conf": []byte(data)},
 		}


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

The bug is that FluentBitConfig controller will generate config files for every custom resource it is watching (FluentBitConfig, Input, Filter, Output). This causes unnecessary creation of config files, like the red rectangle shows.

The correct way is to generate config file based on FluentBitConfig resource only, like the yellow arrow points out.

![image](https://user-images.githubusercontent.com/22350668/83383348-80c7c400-a417-11ea-81e4-234ee900a223.png)
