### PR TITLE
add yaml templates for http demo

### DIFF
--- a/docs/user-guides/forwarding-logs-via-http/README.md
+++ b/docs/user-guides/forwarding-logs-via-http/README.md
@@ -17,6 +17,8 @@ kubectl apply -f manifests/setup/
 kubectl apply -f docs/user-guides/forwarding-logs-via-http/deploy/
 ```
 
+Note: for KubeSphere users who have enabled logging, you can simply apply the YAML files in the folder `kubesphere`. Don't forget to adapt the http receiver endpoint to your setup.
+
 # Sample Output
 
 The logging agents (fluent bit) forward logs in the following format:
@@ -85,3 +87,7 @@ The logging agents (fluent bit) forward logs in the following format:
     }
 ]
 ```
+
+# TLS Support
+
+Please read comments on the file `deploy/output-http.yaml` for how to send logs to an HTTPS endpoint.

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/filter-grep.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/filter-grep.yaml
@@ -1,0 +1,36 @@
+apiVersion: logging.kubesphere.io/v1alpha2
+kind: Filter
+metadata:
+  name: erro-grep
+  namespace: kubesphere-logging-system
+  labels:
+    logging.kubesphere.io/enabled: "true"
+    app.kubernetes.io/version: v0.2.0
+spec:
+  match: kube_erro
+  filters:
+  - grep:
+      # Note that the value format is `KEY REGEX`. Only one space in between.
+      regex: "log \\sERRO\\s"
+  - kubernetes:
+      kubeURL: https://kubernetes.default.svc:443
+      kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      labels: false
+      annotations: false
+  - nest:
+      operation: lift
+      nestedUnder: kubernetes
+      addPrefix: kubernetes_
+  - modify:
+      rules:
+      - remove: stream
+      - remove: kubernetes_pod_id
+      - remove: kubernetes_host
+      - remove: kubernetes_container_hash
+  - nest:
+      operation: nest
+      wildcard:
+      - kubernetes_*
+      nestUnder: kubernetes
+      removePrefix: kubernetes_

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/input-tail.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/input-tail.yaml
@@ -1,0 +1,20 @@
+apiVersion: logging.kubesphere.io/v1alpha2
+kind: Input
+metadata:
+  name: erro-tail
+  namespace: kubesphere-logging-system
+  labels:
+    logging.kubesphere.io/enabled: "true"
+    app.kubernetes.io/version: v0.2.0
+spec:
+  tail:
+    tag: kube_erro
+    path: /var/log/containers/*.log
+    # Exclude logs from system components
+    excludePath: /var/log/containers/*_kube*-system_*.log
+    parser: docker
+    refreshIntervalSeconds: 10
+    memBufLimit: 5MB
+    skipLongLines: true
+    db: /fluent-bit/tail/pos-erro.db
+    dbSync: Normal

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/output-http.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/output-http.yaml
@@ -1,12 +1,15 @@
 apiVersion: logging.kubesphere.io/v1alpha2
 kind: Output
 metadata:
-  name: http
+  name: errohttp
+  namespace: kubesphere-logging-system
   labels:
-    http-output-demo: "true"
+    logging.kubesphere.io/enabled: "true"
+    app.kubernetes.io/version: v0.2.0
 spec:
-  match: kube.*
+  match: kube_erro
   http:
+    # Change the host and port to your receiver endpoint
     host: "log-receiver"
     port: 8080
     format: "json"


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Add YAML templates for http demo.

Now, for KubeSphere users who have enabled logging, they can simply apply these YAML files in the folder `kubesphere`. The only effort required by users is to modify output host (`log-receiver.default.svc` by default) and port (`8080` by default) as per their own setup.
