### PR TITLE
update images

### DIFF
--- a/docs/user-guides/forwarding-logs-via-http/Dockerfile
+++ b/docs/user-guides/forwarding-logs-via-http/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14-stretch
 
-COPY main /main
-RUN chmod +x /main
+COPY main.go /go/src/main.go
+RUN go build /go/src/main.go
 
 CMD ["/main"]

--- a/docs/user-guides/forwarding-logs-via-http/README.md
+++ b/docs/user-guides/forwarding-logs-via-http/README.md
@@ -7,7 +7,7 @@ This tutorial guides you on how to filter error logs and send them out via HTTP.
 First, deploy HTTP sample server for receiving logs (see main.go).
 
 ```shell
-kubectl create deploy log-receiver --image=vasth/web0:latest --port=8080
+kubectl create deploy log-receiver --image=kubespheredev/example-log-receiver --port=8080
 kubectl expose deploy log-receiver --port=8080 --target-port=8080
 ```  
 Second, setup the logging pipeline. It deploys a log generator and logging agents (fluent bit). The logging agent will forward all error logs containing `ERRO` to the sample server above.
@@ -87,6 +87,8 @@ The logging agents (fluent bit) forward logs in the following format:
     }
 ]
 ```
+
+You may check out the logs of log-receiver.
 
 # TLS Support
 

--- a/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
@@ -4,9 +4,8 @@ metadata:
   name: fluent-bit
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.4.6
 spec:
-  image: vasth/fluent-bit
+  image: kubespheredev/fluent-bit:v1.6.2
   positionDB:
     emptyDir: {}
   fluentBitConfigName: fluent-bit-config

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/filter-grep.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/filter-grep.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube_erro
   filters:

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/input-tail.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/input-tail.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   tail:
     tag: kube_erro

--- a/docs/user-guides/forwarding-logs-via-http/kubesphere/output-http.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/kubesphere/output-http.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube_erro
   http:

--- a/docs/user-guides/forwarding-logs-via-http/main.go
+++ b/docs/user-guides/forwarding-logs-via-http/main.go
@@ -13,7 +13,7 @@ type Message struct {
 	Time   string `json:"time"`
 }
 
-// Sample HTTP server for this demo
+// Sample HTTP receiver for this demo
 func main() {
 	h := func(w http.ResponseWriter, req *http.Request) {
 		b, err := ioutil.ReadAll(req.Body)

--- a/manifests/logging-stack/filter-kubernetes.yaml
+++ b/manifests/logging-stack/filter-kubernetes.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "true"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube.*
   filters:

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.4.6
 spec:
-  image: kubespheredev/fluent-bit:v1.4.6
+  image: kubespheredev/fluent-bit:v1.6.2
   positionDB:
     emptyDir: {}
   fluentBitConfigName: fluent-bit-config

--- a/manifests/logging-stack/fluentbitconfig-fluentBitConfig.yaml
+++ b/manifests/logging-stack/fluentbitconfig-fluentBitConfig.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.5.0
 spec:
   service:
     parsersFile: parsers.conf

--- a/manifests/logging-stack/input-tail.yaml
+++ b/manifests/logging-stack/input-tail.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "true"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   tail:
     tag: kube.*

--- a/manifests/logging-stack/output-elasticsearch.yaml
+++ b/manifests/logging-stack/output-elasticsearch.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "true"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube.*
   es:

--- a/manifests/logging-stack/output-forward.yaml
+++ b/manifests/logging-stack/output-forward.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "false"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube.*
   forward:

--- a/manifests/logging-stack/output-kafka.yaml
+++ b/manifests/logging-stack/output-kafka.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "false"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: kube.*
   kafka:

--- a/manifests/quick-start/fluentbit-fluentBit.yaml
+++ b/manifests/quick-start/fluentbit-fluentBit.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.4.6
 spec:
-  image: kubespheredev/fluent-bit:v1.4.6
+  image: kubespheredev/fluent-bit:v1.6.2
   fluentBitConfigName: fluent-bit-config

--- a/manifests/quick-start/fluentbitconfig-fluentBitConfig.yaml
+++ b/manifests/quick-start/fluentbitconfig-fluentBitConfig.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.5.0
 spec:
   inputSelector:
     matchLabels:

--- a/manifests/quick-start/input-dummy.yaml
+++ b/manifests/quick-start/input-dummy.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   dummy:
     tag: my_dummy

--- a/manifests/quick-start/output-stdout.yaml
+++ b/manifests/quick-start/output-stdout.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: "*"
   stdout: {}

--- a/manifests/regex-parser/filter-parser.yaml
+++ b/manifests/regex-parser/filter-parser.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: "*"
   filters:

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.4.6
 spec:
-  image: vasth/fluent-bit
+  image: kubespheredev/fluent-bit:v1.6.2
   fluentBitConfigName: fluent-bit-config

--- a/manifests/regex-parser/fluentbitconfig-fluentBitConfig.yaml
+++ b/manifests/regex-parser/fluentbitconfig-fluentBitConfig.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/version: v1.4.6
 spec:
   service:
+    # To use parser, you must enable parsersFile by setting its value to parsers.conf
     parsersFile: parsers.conf
   inputSelector:
     matchLabels:

--- a/manifests/regex-parser/input-tail.yaml
+++ b/manifests/regex-parser/input-tail.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     logging.kubesphere.io/enabled: "true"
     logging.kubesphere.io/component: logging
-    app.kubernetes.io/version: v0.2.0
 spec:
   tail:
     tag: "*"

--- a/manifests/regex-parser/output-stdout.yaml
+++ b/manifests/regex-parser/output-stdout.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   match: "*"
   stdout: {}

--- a/manifests/regex-parser/parser-regex.yaml
+++ b/manifests/regex-parser/parser-regex.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kubesphere-logging-system
   labels:
     logging.kubesphere.io/enabled: "true"
-    app.kubernetes.io/version: v0.2.0
 spec:
   regex:
     timeKey: time

--- a/manifests/setup/fluentbit-operator-clusterRole.yaml
+++ b/manifests/setup/fluentbit-operator-clusterRole.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: fluentbit-operator
-    app.kubernetes.io/version: v0.2.0
   name: kubesphere:operator:fluentbit-operator
 rules:
   - apiGroups:

--- a/manifests/setup/fluentbit-operator-clusterRoleBinding.yaml
+++ b/manifests/setup/fluentbit-operator-clusterRoleBinding.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: fluentbit-operator
-    app.kubernetes.io/version: v0.2.0
   name: kubesphere:operator:fluentbit-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/setup/fluentbit-operator-deployment.yaml
+++ b/manifests/setup/fluentbit-operator-deployment.yaml
@@ -6,19 +6,16 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluentbit-operator
-    app.kubernetes.io/version: v0.2.0
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: operator
       app.kubernetes.io/name: fluentbit-operator
-      app.kubernetes.io/version: v0.2.0
   template:
     metadata:
       labels:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: fluentbit-operator
-        app.kubernetes.io/version: v0.2.0
     spec:
       volumes:
       - name: env
@@ -42,7 +39,7 @@ spec:
           mountPath: /var/run/docker.sock
       containers:
       - name: fluentbit-operator
-        image: 'kubespheredev/fluentbit-operator:v0.2.0'
+        image: 'kubespheredev/fluentbit-operator:v0.3.0'
         resources:
           limits:
             cpu: 100m

--- a/manifests/setup/fluentbit-operator-serviceAccount.yaml
+++ b/manifests/setup/fluentbit-operator-serviceAccount.yaml
@@ -4,6 +4,5 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluentbit-operator
-    app.kubernetes.io/version: v0.2.0
   name: fluentbit-operator
   namespace: kubesphere-logging-system


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

- update fluent-bit to v1.6.2, fluentbit-operator to v0.3.0
- remove `app.kubernetes.io/version: v0.2.0` from meta.labels. It is to avoid massive modification in future releases of fluent bit operator