### PR TITLE
update fluent-bit images

### DIFF
--- a/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubespheredev/fluent-bit:v1.6.2
+  image: kubespheredev/fluent-bit:v1.7.3
   positionDB:
     emptyDir: {}
   fluentBitConfigName: fluent-bit-config

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.6.9
+  image: kubespheredev/fluent-bit:v1.7.3
   positionDB:
     emptyDir: {}
   fluentBitConfigName: fluent-bit-config

--- a/manifests/quick-start/fluentbit-fluentBit.yaml
+++ b/manifests/quick-start/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubespheredev/fluent-bit:v1.6.2
+  image: kubespheredev/fluent-bit:v1.7.3
   fluentBitConfigName: fluent-bit-config

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubespheredev/fluent-bit:v1.6.2
+  image: kubespheredev/fluent-bit:v1.7.3
   fluentBitConfigName: fluent-bit-config


### PR DESCRIPTION
I have updated Fluent-bit to v1.7.3 in the Kubesphere cluster, and the cluster is running fine. Below are the screenshots of the cluster running.
![容器](https://user-images.githubusercontent.com/39892300/118928021-3cf60380-b975-11eb-80fd-164f5dcdf379.png)
![调度信息](https://user-images.githubusercontent.com/39892300/118928036-41222100-b975-11eb-8c6c-f5ad6aecd87d.jpg)
![](https://user-images.githubusercontent.com/39892300/118928051-441d1180-b975-11eb-9203-95ed38ab1220.png)


