### PR TITLE
add support for plugin alias property in input and output specs

### DIFF
--- a/api/fluentbitoperator/v1alpha2/input_types.go
+++ b/api/fluentbitoperator/v1alpha2/input_types.go
@@ -30,6 +30,9 @@ import (
 
 // InputSpec defines the desired state of Input
 type InputSpec struct {
+	// A user friendly alias name for this input plugin.
+	// Used in metrics for distinction of each configured input.
+	Alias string `json:"alias,omitempty"`
 	// Dummy defines Dummy Input configuration.
 	Dummy *input.Dummy `json:"dummy,omitempty"`
 	// Tail defines Tail Input configuration.
@@ -69,6 +72,9 @@ func (list InputList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Input]\n")
 			buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+			if item.Spec.Alias != "" {
+				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
+			}
 			kvs, err := p.Params(sl)
 			if err != nil {
 				return err

--- a/api/fluentbitoperator/v1alpha2/output_types.go
+++ b/api/fluentbitoperator/v1alpha2/output_types.go
@@ -36,6 +36,9 @@ type OutputSpec struct {
 	// A regular expression to match against the tags of incoming records.
 	// Use this option if you want to use the full regex syntax.
 	MatchRegex string `json:"matchRegex,omitempty"`
+	// A user friendly alias name for this output plugin.
+	// Used in metrics for distinction of each configured output.
+	Alias string `json:"alias,omitempty"`
 	// Elasticsearch defines Elasticsearch Output configuration.
 	Elasticsearch *output.Elasticsearch `json:"es,omitempty"`
 	// File defines File Output configuration.
@@ -94,6 +97,9 @@ func (list OutputList) Load(sl plugins.SecretLoader) (string, error) {
 			}
 			if item.Spec.MatchRegex != "" {
 				buf.WriteString(fmt.Sprintf("    Match_Regex    %s\n", item.Spec.MatchRegex))
+			}
+			if item.Spec.Alias != "" {
+				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {

--- a/config/crd/bases/logging.kubesphere.io_inputs.yaml
+++ b/config/crd/bases/logging.kubesphere.io_inputs.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: InputSpec defines the desired state of Input
             properties:
+              alias:
+                description: A user friendly alias name for this input plugin. Used
+                  in metrics for distinction of each configured input.
+                type: string
               dummy:
                 description: Dummy defines Dummy Input configuration.
                 properties:

--- a/config/crd/bases/logging.kubesphere.io_outputs.yaml
+++ b/config/crd/bases/logging.kubesphere.io_outputs.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: OutputSpec defines the desired state of Output
             properties:
+              alias:
+                description: A user friendly alias name for this output plugin. Used
+                  in metrics for distinction of each configured output.
+                type: string
               es:
                 description: Elasticsearch defines Elasticsearch Output configuration.
                 properties:

--- a/manifests/setup/fluentbit-operator-crd.yaml
+++ b/manifests/setup/fluentbit-operator-crd.yaml
@@ -2630,6 +2630,10 @@ spec:
           spec:
             description: InputSpec defines the desired state of Input
             properties:
+              alias:
+                description: A user friendly alias name for this input plugin. Used
+                  in metrics for distinction of each configured input.
+                type: string
               dummy:
                 description: Dummy defines Dummy Input configuration.
                 properties:
@@ -2890,6 +2894,10 @@ spec:
           spec:
             description: OutputSpec defines the desired state of Output
             properties:
+              alias:
+                description: A user friendly alias name for this output plugin. Used
+                  in metrics for distinction of each configured output.
+                type: string
               es:
                 description: Elasticsearch defines Elasticsearch Output configuration.
                 properties:


### PR DESCRIPTION
This PR adds support for [Alias property](https://docs.fluentbit.io/manual/administration/monitoring#configuring-aliases) of Input and Output plugin specs, as these can be useful for monitoring purposes.