### PR TITLE
update deployment tag to v0.7.0

### DIFF
--- a/manifests/setup/fluentbit-operator-deployment.yaml
+++ b/manifests/setup/fluentbit-operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           mountPath: /var/run/docker.sock
       containers:
       - name: fluentbit-operator
-        image: 'kubesphere/fluentbit-operator:v0.6.2'
+        image: 'kubesphere/fluentbit-operator:v0.7.0'
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
[As per comment](https://github.com/kubesphere/fluentbit-operator/pull/70#issuecomment-870425610) in #70, updating the deployment tag to tag `v0.7.0` in master branch.