### PR TITLE
add hostpath

### DIFF
--- a/config/samples/logging_v1alpha2_fluentbit.yaml
+++ b/config/samples/logging_v1alpha2_fluentbit.yaml
@@ -8,5 +8,6 @@ spec:
   image: kubespheredev/fluent-bit:v1.5.0
   imagePullPolicy: IfNotPresent
   positionDB:
-    emptyDir: {}
+    hostPath:
+      path: /var/lib/fluent-bit/
   fluentBitConfigName: fluentbitconfig-sample

--- a/config/samples/logging_v1alpha2_input.yaml
+++ b/config/samples/logging_v1alpha2_input.yaml
@@ -12,5 +12,5 @@ spec:
     refreshIntervalSeconds: 10
     memBufLimit: 5MB
     skipLongLines: true
-    db: /fluent-bit/tail/pos.db
+    db: /tail/pos.db
     dbSync: Normal

--- a/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   image: kubespheredev/fluent-bit:v1.7.3
   positionDB:
-    emptyDir: {}
+    hostPath:
+      path: /var/lib/fluent-bit/
   fluentBitConfigName: fluent-bit-config
   tolerations:
     - operator: Exists

--- a/docs/user-guides/forwarding-logs-via-http/deploy/input-tail.yaml
+++ b/docs/user-guides/forwarding-logs-via-http/deploy/input-tail.yaml
@@ -12,5 +12,5 @@ spec:
     refreshIntervalSeconds: 10
     memBufLimit: 5MB
     skipLongLines: true
-    db: /fluent-bit/tail/pos.db
+    db: /tail/pos.db
     dbSync: Normal

--- a/manifests/logging-stack/auditd/input-auditd.yaml
+++ b/manifests/logging-stack/auditd/input-auditd.yaml
@@ -12,5 +12,5 @@ spec:
     path: /var/log/audit/audit.log
     refreshIntervalSeconds: 10
     memBufLimit: 5MB
-    db: /fluent-bit/tail/auditd.db
+    db: /tail/auditd.db
     dbSync: Normal

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   image: kubespheredev/fluent-bit:v1.7.3
   positionDB:
-    emptyDir: {}
+    hostPath:
+      path: /var/lib/fluent-bit/
   resources:
     requests:
       cpu: 10m

--- a/manifests/logging-stack/input-systemd-docker.yaml
+++ b/manifests/logging-stack/input-systemd-docker.yaml
@@ -10,7 +10,7 @@ spec:
   systemd:
     tag: service.docker
     path: /var/log/journal
-    db: /fluent-bit/tail/docker.db
+    db: /systemd/docker.db
     dbSync: Normal
     systemdFilter:
       - _SYSTEMD_UNIT=docker.service

--- a/manifests/logging-stack/input-systemd-kubelet.yaml
+++ b/manifests/logging-stack/input-systemd-kubelet.yaml
@@ -10,7 +10,7 @@ spec:
   systemd:
     tag: service.kubelet
     path: /var/log/journal
-    db: /fluent-bit/tail/kubelet.db
+    db: /systemd/kubelet.db
     dbSync: Normal
     systemdFilter:
       - _SYSTEMD_UNIT=kubelet.service

--- a/manifests/logging-stack/input-tail.yaml
+++ b/manifests/logging-stack/input-tail.yaml
@@ -14,5 +14,5 @@ spec:
     refreshIntervalSeconds: 10
     memBufLimit: 5MB
     skipLongLines: true
-    db: /fluent-bit/tail/pos.db
+    db: /tail/pos.db
     dbSync: Normal

--- a/manifests/regex-parser/input-tail.yaml
+++ b/manifests/regex-parser/input-tail.yaml
@@ -14,5 +14,5 @@ spec:
     refreshIntervalSeconds: 10
     memBufLimit: 5MB
     skipLongLines: true
-    db: /fluent-bit/tail/pos.db
+    db: /tail/pos.db
     dbSync: Normal


### PR DESCRIPTION
Signed-off-by: wenchajun <995729579@qq.com>

add hostPath config configuration.
In default mode, log loss occurs if FluentBit POD is removed during log generation. 
You can modify the input.spec.dbSync and input.spec.refreshIntervalSeconds fields for better performance. However, log generation is slightly faster,it is still possible to lose a small number of logs.

 - input.spec.dbSync: FULL
When synchronous is FULL, the SQLite database engine will use the xSync method of the VFS to ensure that all content is safely written to the disk surface prior to continuing. This ensures that an operating system crash or power failure will not corrupt the database. FULL synchronous is very safe, but it is also slower.