### PR TITLE
update fluent bit image to 1.7.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 # Image URL to use all building/pushing image targets
-FB_IMG ?= kubespheredev/fluent-bit:v1.7.3
+FB_IMG ?= kubespheredev/fluent-bit:v1.7.8
 OP_IMG ?= kubespheredev/fluentbit-operator:$(VERSION)
 MIGRATOR_IMG ?= kubespheredev/fluentbit-operator:migrator
 AMD64 ?= -amd64

--- a/cmd/fluent-bit-watcher/Dockerfile
+++ b/cmd/fluent-bit-watcher/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /fluent-bit
 RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o fluent-bit main.go
 
 # FROM gcr.io/distroless/cc-debian10
-FROM fluent/fluent-bit:1.7.3
+FROM fluent/fluent-bit:1.7.9
 MAINTAINER KubeSphere <kubesphere@yunify.com>
 LABEL Description="Fluent Bit docker image" Vendor="KubeSphere" Version="1.0"
 


### PR DESCRIPTION
Revisiting [#75](https://github.com/kubesphere/fluentbit-operator/pull/75) this today and thinking some more... Did I do this incorrectly? `fluent-bit-watcher` is part of the actual fluent-bit image. So I should have been updating that too...?

This PR updates the base fluent/fluent-bit image to latest in 1.7 tag, and updates our build tag in Makefile.

[fluent-bit 1.8 was released](https://fluentbit.io/announcements/v1.8.0/) but that should go as a separate release perhaps.