### PR TITLE
update changelog, dummy docs, and image version in manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.7.1 / 2021-07-08
+
+- [ENHANCEMENT] fluent-bit-watcher: goroutine synchronization improvements. #74
+- [CHANGE] add hostpath to sample configurations and manifests. #72
+- [BUGFIX] Fix bug operator may crash when load plugin. #77
+
+## 0.7.0 / 2021-06-29
+
+- [ENHANCEMENT] Add support for plugin alias property in input and output specs. #64.
+- [CHANGE] Add fluent-bit-watcher. #62.
+
 ## 0.6.2 / 2021-06-11
 
 - [ENHANCEMENT] Update Kubernetes dependencies.

--- a/docs/plugins/input/dummy.md
+++ b/docs/plugins/input/dummy.md
@@ -8,3 +8,4 @@ The dummy input plugin, generates dummy events. It is useful for testing, debugg
 | tag | Tag name associated to all records comming from this plugin. | string |
 | dummy | Dummy JSON record. | string |
 | rate | Events number generated per second. | *int32 |
+| samples | Sample events to generate. | *int32 |

--- a/manifests/setup/fluentbit-operator-deployment.yaml
+++ b/manifests/setup/fluentbit-operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           mountPath: /var/run/docker.sock
       containers:
       - name: fluentbit-operator
-        image: 'kubesphere/fluentbit-operator:v0.7.0'
+        image: 'kubesphere/fluentbit-operator:v0.7.1'
         resources:
           limits:
             cpu: 100m

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3187,7 +3187,7 @@ spec:
         app.kubernetes.io/name: fluentbit-operator
     spec:
       containers:
-      - image: kubesphere/fluentbit-operator:v0.7.0
+      - image: kubesphere/fluentbit-operator:v0.7.1
         name: fluentbit-operator
         resources:
           limits:


### PR DESCRIPTION
Just some cleanup to bring in latest 0.7 changes into master...
- Updates `dummy` plugin docs.
- Updates changelog.
- Updates the image used in manifests to `v0.7.1` tag.