### PR TITLE
Fix log loss bug

### DIFF
--- a/cmd/fluent-bit-watcher/main.go
+++ b/cmd/fluent-bit-watcher/main.go
@@ -217,7 +217,7 @@ func stop() {
 		return
 	}
 
-	if err := cmd.Process.Kill(); err != nil {
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		_ = level.Info(logger).Log("msg", "Kill Fluent Bit error", "error", err)
 	} else {
 		_ = level.Info(logger).Log("msg", "Killed Fluent Bit")


### PR DESCRIPTION
Signed-off-by: wenchajun <dehaocheng@yunify.com>

The SIGTERM signal is a generic signal used to cause program termination. Unlike SIGKILL, this signal can be blocked, handled, and ignored. It is the normal way to politely ask a program to terminate.