### PR TITLE
Added support to use imagePullSecrets defined in values.yaml file

### DIFF
--- a/chart/fluentbit-operator/values.yaml
+++ b/chart/fluentbit-operator/values.yaml
@@ -46,12 +46,21 @@ resources:
   fluentbit:
   # Fluent Bit resources. User can adjust it based on the log volume.
     resources:
+<<<<<<< HEAD
       limits:
         cpu: 500m
         memory: 200Mi
       requests:
         cpu: 10m
         memory: 25Mi
+=======
+       limits:
+         cpu: 500m
+         memory: 200Mi
+       requests:
+         cpu: 10m
+         memory: 25Mi
+>>>>>>> 0d56c82 (separated resources section for the operator and fluentbit)
 
   operator:
   # FluentBit operator resources. Usually user needn't to adjust these.
@@ -59,6 +68,7 @@ resources:
       limits:
         cpu: 200m
         memory: 50Mi
+<<<<<<< HEAD
       requests:
         cpu: 100m
         memory: 20Mi
@@ -72,6 +82,11 @@ input:
   tail:
     memBufLimit: 5MB
 
+=======
+    requests:
+      cpu: 100m
+      memory: 20Mi
+>>>>>>> 0d56c82 (separated resources section for the operator and fluentbit)
 
 output:
   #Configure the output plugin parameter in FluentBit.

--- a/chart/fluentbit-operator/values.yaml
+++ b/chart/fluentbit-operator/values.yaml
@@ -46,21 +46,12 @@ resources:
   fluentbit:
   # Fluent Bit resources. User can adjust it based on the log volume.
     resources:
-<<<<<<< HEAD
-      limits:
-        cpu: 500m
-        memory: 200Mi
-      requests:
-        cpu: 10m
-        memory: 25Mi
-=======
        limits:
          cpu: 500m
          memory: 200Mi
        requests:
          cpu: 10m
          memory: 25Mi
->>>>>>> 0d56c82 (separated resources section for the operator and fluentbit)
 
   operator:
   # FluentBit operator resources. Usually user needn't to adjust these.
@@ -68,25 +59,9 @@ resources:
       limits:
         cpu: 200m
         memory: 50Mi
-<<<<<<< HEAD
-      requests:
-        cpu: 100m
-        memory: 20Mi
-
-#Set a limit of memory that Tail plugin can use when appending data to the Engine.
-#If the limit is reach, it will be paused; when the data is flushed it resumes.
-#if the inboud traffic is less than 2.4Mbps, setting memBufLimit to 5MB is enough
-#if the inboud traffic is less than 4.0Mbps, setting memBufLimit to 10MB is enough
-#if the inboud traffic is less than 13.64Mbps, setting memBufLimit to 50MB is enough
-input:
-  tail:
-    memBufLimit: 5MB
-
-=======
     requests:
       cpu: 100m
       memory: 20Mi
->>>>>>> 0d56c82 (separated resources section for the operator and fluentbit)
 
 output:
   #Configure the output plugin parameter in FluentBit.

--- a/chart/fluentbit-operator/values.yaml
+++ b/chart/fluentbit-operator/values.yaml
@@ -63,6 +63,16 @@ resources:
       cpu: 100m
       memory: 20Mi
 
+#Set a limit of memory that Tail plugin can use when appending data to the Engine.
+#If the limit is reach, it will be paused; when the data is flushed it resumes.
+#if the inboud traffic is less than 2.4Mbps, setting memBufLimit to 5MB is enough
+#if the inboud traffic is less than 4.0Mbps, setting memBufLimit to 10MB is enough
+#if the inboud traffic is less than 13.64Mbps, setting memBufLimit to 50MB is enough
+input:
+  tail:
+    memBufLimit: 5MB
+
+
 output:
   #Configure the output plugin parameter in FluentBit.
   #You can set enable to true to output logs to the specified location.


### PR DESCRIPTION
in fluentbit-operator deployment file, there was no support for the imagePullSecrets though it was available in values.yaml file. I will add in other templates also