### PR TITLE
update groupname for client-gen to logging.kubesphere.io

### DIFF
--- a/api/fluentbitoperator/v1alpha2/doc.go
+++ b/api/fluentbitoperator/v1alpha2/doc.go
@@ -1,0 +1,19 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:deepcopy-gen=package
+// +groupName=logging.kubesphere.io
+
+package v1alpha2 // import "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"

--- a/api/generated/clientset/versioned/clientset.go
+++ b/api/generated/clientset/versioned/clientset.go
@@ -22,24 +22,24 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-	fluentbitoperatorv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2"
+	loggingv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2"
 )
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	FluentbitoperatorV1alpha2() fluentbitoperatorv1alpha2.FluentbitoperatorV1alpha2Interface
+	LoggingV1alpha2() loggingv1alpha2.LoggingV1alpha2Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	fluentbitoperatorV1alpha2 *fluentbitoperatorv1alpha2.FluentbitoperatorV1alpha2Client
+	loggingV1alpha2 *loggingv1alpha2.LoggingV1alpha2Client
 }
 
-// FluentbitoperatorV1alpha2 retrieves the FluentbitoperatorV1alpha2Client
-func (c *Clientset) FluentbitoperatorV1alpha2() fluentbitoperatorv1alpha2.FluentbitoperatorV1alpha2Interface {
-	return c.fluentbitoperatorV1alpha2
+// LoggingV1alpha2 retrieves the LoggingV1alpha2Client
+func (c *Clientset) LoggingV1alpha2() loggingv1alpha2.LoggingV1alpha2Interface {
+	return c.loggingV1alpha2
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -63,7 +63,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 	var cs Clientset
 	var err error
-	cs.fluentbitoperatorV1alpha2, err = fluentbitoperatorv1alpha2.NewForConfig(&configShallowCopy)
+	cs.loggingV1alpha2, err = loggingv1alpha2.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
-	cs.fluentbitoperatorV1alpha2 = fluentbitoperatorv1alpha2.NewForConfigOrDie(c)
+	cs.loggingV1alpha2 = loggingv1alpha2.NewForConfigOrDie(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &cs
@@ -88,7 +88,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.fluentbitoperatorV1alpha2 = fluentbitoperatorv1alpha2.New(c)
+	cs.loggingV1alpha2 = loggingv1alpha2.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/api/generated/clientset/versioned/fake/clientset_generated.go
+++ b/api/generated/clientset/versioned/fake/clientset_generated.go
@@ -23,8 +23,8 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
 	clientset "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned"
-	fluentbitoperatorv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2"
-	fakefluentbitoperatorv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake"
+	loggingv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2"
+	fakeloggingv1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -74,7 +74,7 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 
 var _ clientset.Interface = &Clientset{}
 
-// FluentbitoperatorV1alpha2 retrieves the FluentbitoperatorV1alpha2Client
-func (c *Clientset) FluentbitoperatorV1alpha2() fluentbitoperatorv1alpha2.FluentbitoperatorV1alpha2Interface {
-	return &fakefluentbitoperatorv1alpha2.FakeFluentbitoperatorV1alpha2{Fake: &c.Fake}
+// LoggingV1alpha2 retrieves the LoggingV1alpha2Client
+func (c *Clientset) LoggingV1alpha2() loggingv1alpha2.LoggingV1alpha2Interface {
+	return &fakeloggingv1alpha2.FakeLoggingV1alpha2{Fake: &c.Fake}
 }

--- a/api/generated/clientset/versioned/fake/register.go
+++ b/api/generated/clientset/versioned/fake/register.go
@@ -22,14 +22,14 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	fluentbitoperatorv1alpha2 "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
+	loggingv1alpha2 "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	fluentbitoperatorv1alpha2.AddToScheme,
+	loggingv1alpha2.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/api/generated/clientset/versioned/scheme/register.go
+++ b/api/generated/clientset/versioned/scheme/register.go
@@ -22,14 +22,14 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	fluentbitoperatorv1alpha2 "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
+	loggingv1alpha2 "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
 )
 
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	fluentbitoperatorv1alpha2.AddToScheme,
+	loggingv1alpha2.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_filter.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_filter.go
@@ -30,13 +30,13 @@ import (
 
 // FakeFilters implements FilterInterface
 type FakeFilters struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var filtersResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "filters"}
+var filtersResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "filters"}
 
-var filtersKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "Filter"}
+var filtersKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "Filter"}
 
 // Get takes name of the filter, and returns the corresponding filter object, and an error if there is any.
 func (c *FakeFilters) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.Filter, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbit.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbit.go
@@ -30,13 +30,13 @@ import (
 
 // FakeFluentBits implements FluentBitInterface
 type FakeFluentBits struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var fluentbitsResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "fluentbits"}
+var fluentbitsResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "fluentbits"}
 
-var fluentbitsKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "FluentBit"}
+var fluentbitsKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "FluentBit"}
 
 // Get takes name of the fluentBit, and returns the corresponding fluentBit object, and an error if there is any.
 func (c *FakeFluentBits) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.FluentBit, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbitconfig.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbitconfig.go
@@ -30,13 +30,13 @@ import (
 
 // FakeFluentBitConfigs implements FluentBitConfigInterface
 type FakeFluentBitConfigs struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var fluentbitconfigsResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "fluentbitconfigs"}
+var fluentbitconfigsResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "fluentbitconfigs"}
 
-var fluentbitconfigsKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "FluentBitConfig"}
+var fluentbitconfigsKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "FluentBitConfig"}
 
 // Get takes name of the fluentBitConfig, and returns the corresponding fluentBitConfig object, and an error if there is any.
 func (c *FakeFluentBitConfigs) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.FluentBitConfig, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbitoperator_client.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_fluentbitoperator_client.go
@@ -22,37 +22,37 @@ import (
 	v1alpha2 "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2"
 )
 
-type FakeFluentbitoperatorV1alpha2 struct {
+type FakeLoggingV1alpha2 struct {
 	*testing.Fake
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) Filters(namespace string) v1alpha2.FilterInterface {
+func (c *FakeLoggingV1alpha2) Filters(namespace string) v1alpha2.FilterInterface {
 	return &FakeFilters{c, namespace}
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) FluentBits(namespace string) v1alpha2.FluentBitInterface {
+func (c *FakeLoggingV1alpha2) FluentBits(namespace string) v1alpha2.FluentBitInterface {
 	return &FakeFluentBits{c, namespace}
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) FluentBitConfigs(namespace string) v1alpha2.FluentBitConfigInterface {
+func (c *FakeLoggingV1alpha2) FluentBitConfigs(namespace string) v1alpha2.FluentBitConfigInterface {
 	return &FakeFluentBitConfigs{c, namespace}
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) Inputs(namespace string) v1alpha2.InputInterface {
+func (c *FakeLoggingV1alpha2) Inputs(namespace string) v1alpha2.InputInterface {
 	return &FakeInputs{c, namespace}
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) Outputs(namespace string) v1alpha2.OutputInterface {
+func (c *FakeLoggingV1alpha2) Outputs(namespace string) v1alpha2.OutputInterface {
 	return &FakeOutputs{c, namespace}
 }
 
-func (c *FakeFluentbitoperatorV1alpha2) Parsers(namespace string) v1alpha2.ParserInterface {
+func (c *FakeLoggingV1alpha2) Parsers(namespace string) v1alpha2.ParserInterface {
 	return &FakeParsers{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeFluentbitoperatorV1alpha2) RESTClient() rest.Interface {
+func (c *FakeLoggingV1alpha2) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_input.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_input.go
@@ -30,13 +30,13 @@ import (
 
 // FakeInputs implements InputInterface
 type FakeInputs struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var inputsResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "inputs"}
+var inputsResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "inputs"}
 
-var inputsKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "Input"}
+var inputsKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "Input"}
 
 // Get takes name of the input, and returns the corresponding input object, and an error if there is any.
 func (c *FakeInputs) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.Input, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_output.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_output.go
@@ -30,13 +30,13 @@ import (
 
 // FakeOutputs implements OutputInterface
 type FakeOutputs struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var outputsResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "outputs"}
+var outputsResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "outputs"}
 
-var outputsKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "Output"}
+var outputsKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "Output"}
 
 // Get takes name of the output, and returns the corresponding output object, and an error if there is any.
 func (c *FakeOutputs) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.Output, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_parser.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_parser.go
@@ -30,13 +30,13 @@ import (
 
 // FakeParsers implements ParserInterface
 type FakeParsers struct {
-	Fake *FakeFluentbitoperatorV1alpha2
+	Fake *FakeLoggingV1alpha2
 	ns   string
 }
 
-var parsersResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "parsers"}
+var parsersResource = schema.GroupVersionResource{Group: "logging.kubesphere.io", Version: "v1alpha2", Resource: "parsers"}
 
-var parsersKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "Parser"}
+var parsersKind = schema.GroupVersionKind{Group: "logging.kubesphere.io", Version: "v1alpha2", Kind: "Parser"}
 
 // Get takes name of the parser, and returns the corresponding parser object, and an error if there is any.
 func (c *FakeParsers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha2.Parser, err error) {

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/filter.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/filter.go
@@ -54,7 +54,7 @@ type filters struct {
 }
 
 // newFilters returns a Filters
-func newFilters(c *FluentbitoperatorV1alpha2Client, namespace string) *filters {
+func newFilters(c *LoggingV1alpha2Client, namespace string) *filters {
 	return &filters{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbit.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbit.go
@@ -55,7 +55,7 @@ type fluentBits struct {
 }
 
 // newFluentBits returns a FluentBits
-func newFluentBits(c *FluentbitoperatorV1alpha2Client, namespace string) *fluentBits {
+func newFluentBits(c *LoggingV1alpha2Client, namespace string) *fluentBits {
 	return &fluentBits{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbitconfig.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbitconfig.go
@@ -54,7 +54,7 @@ type fluentBitConfigs struct {
 }
 
 // newFluentBitConfigs returns a FluentBitConfigs
-func newFluentBitConfigs(c *FluentbitoperatorV1alpha2Client, namespace string) *fluentBitConfigs {
+func newFluentBitConfigs(c *LoggingV1alpha2Client, namespace string) *fluentBitConfigs {
 	return &fluentBitConfigs{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbitoperator_client.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fluentbitoperator_client.go
@@ -22,7 +22,7 @@ import (
 	"kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/scheme"
 )
 
-type FluentbitoperatorV1alpha2Interface interface {
+type LoggingV1alpha2Interface interface {
 	RESTClient() rest.Interface
 	FiltersGetter
 	FluentBitsGetter
@@ -32,37 +32,37 @@ type FluentbitoperatorV1alpha2Interface interface {
 	ParsersGetter
 }
 
-// FluentbitoperatorV1alpha2Client is used to interact with features provided by the fluentbitoperator group.
-type FluentbitoperatorV1alpha2Client struct {
+// LoggingV1alpha2Client is used to interact with features provided by the logging.kubesphere.io group.
+type LoggingV1alpha2Client struct {
 	restClient rest.Interface
 }
 
-func (c *FluentbitoperatorV1alpha2Client) Filters(namespace string) FilterInterface {
+func (c *LoggingV1alpha2Client) Filters(namespace string) FilterInterface {
 	return newFilters(c, namespace)
 }
 
-func (c *FluentbitoperatorV1alpha2Client) FluentBits(namespace string) FluentBitInterface {
+func (c *LoggingV1alpha2Client) FluentBits(namespace string) FluentBitInterface {
 	return newFluentBits(c, namespace)
 }
 
-func (c *FluentbitoperatorV1alpha2Client) FluentBitConfigs(namespace string) FluentBitConfigInterface {
+func (c *LoggingV1alpha2Client) FluentBitConfigs(namespace string) FluentBitConfigInterface {
 	return newFluentBitConfigs(c, namespace)
 }
 
-func (c *FluentbitoperatorV1alpha2Client) Inputs(namespace string) InputInterface {
+func (c *LoggingV1alpha2Client) Inputs(namespace string) InputInterface {
 	return newInputs(c, namespace)
 }
 
-func (c *FluentbitoperatorV1alpha2Client) Outputs(namespace string) OutputInterface {
+func (c *LoggingV1alpha2Client) Outputs(namespace string) OutputInterface {
 	return newOutputs(c, namespace)
 }
 
-func (c *FluentbitoperatorV1alpha2Client) Parsers(namespace string) ParserInterface {
+func (c *LoggingV1alpha2Client) Parsers(namespace string) ParserInterface {
 	return newParsers(c, namespace)
 }
 
-// NewForConfig creates a new FluentbitoperatorV1alpha2Client for the given config.
-func NewForConfig(c *rest.Config) (*FluentbitoperatorV1alpha2Client, error) {
+// NewForConfig creates a new LoggingV1alpha2Client for the given config.
+func NewForConfig(c *rest.Config) (*LoggingV1alpha2Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -71,12 +71,12 @@ func NewForConfig(c *rest.Config) (*FluentbitoperatorV1alpha2Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &FluentbitoperatorV1alpha2Client{client}, nil
+	return &LoggingV1alpha2Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new FluentbitoperatorV1alpha2Client for the given config and
+// NewForConfigOrDie creates a new LoggingV1alpha2Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *FluentbitoperatorV1alpha2Client {
+func NewForConfigOrDie(c *rest.Config) *LoggingV1alpha2Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -84,9 +84,9 @@ func NewForConfigOrDie(c *rest.Config) *FluentbitoperatorV1alpha2Client {
 	return client
 }
 
-// New creates a new FluentbitoperatorV1alpha2Client for the given RESTClient.
-func New(c rest.Interface) *FluentbitoperatorV1alpha2Client {
-	return &FluentbitoperatorV1alpha2Client{c}
+// New creates a new LoggingV1alpha2Client for the given RESTClient.
+func New(c rest.Interface) *LoggingV1alpha2Client {
+	return &LoggingV1alpha2Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -104,7 +104,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FluentbitoperatorV1alpha2Client) RESTClient() rest.Interface {
+func (c *LoggingV1alpha2Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/input.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/input.go
@@ -54,7 +54,7 @@ type inputs struct {
 }
 
 // newInputs returns a Inputs
-func newInputs(c *FluentbitoperatorV1alpha2Client, namespace string) *inputs {
+func newInputs(c *LoggingV1alpha2Client, namespace string) *inputs {
 	return &inputs{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/output.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/output.go
@@ -54,7 +54,7 @@ type outputs struct {
 }
 
 // newOutputs returns a Outputs
-func newOutputs(c *FluentbitoperatorV1alpha2Client, namespace string) *outputs {
+func newOutputs(c *LoggingV1alpha2Client, namespace string) *outputs {
 	return &outputs{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/parser.go
+++ b/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/parser.go
@@ -54,7 +54,7 @@ type parsers struct {
 }
 
 // newParsers returns a Parsers
-func newParsers(c *FluentbitoperatorV1alpha2Client, namespace string) *parsers {
+func newParsers(c *LoggingV1alpha2Client, namespace string) *parsers {
 	return &parsers{
 		client: c.RESTClient(),
 		ns:     namespace,


### PR DESCRIPTION
While the current implementation of go client generation introduced in #51 seems to work in production fine, there appears to be issues when attempting to use the generated fake package. The issue arises with defaulting to groupName taken from package `fluentbitoperator`, which results in the fake package defining resource [types with that group name](https://github.com/kubesphere/fluentbit-operator/blob/master/api/generated/clientset/versioned/typed/fluentbitoperator/v1alpha2/fake/fake_input.go#L37):
```go
var inputsResource = schema.GroupVersionResource{Group: "fluentbitoperator", Version: "v1alpha2", Resource: "inputs"}

var inputsKind = schema.GroupVersionKind{Group: "fluentbitoperator", Version: "v1alpha2", Kind: "Input"}
```

The problem can be simply reproduced by doing something lile:

```go
import (
	...
	"kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2"
	"kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2/plugins"
	fbOutput "kubesphere.io/fluentbit-operator/api/fluentbitoperator/v1alpha2/plugins/output"
	fbcs "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned"
	fbopFake "kubesphere.io/fluentbit-operator/api/generated/clientset/versioned/fake"
)
...
func getFake() fbcs.Interface {
	return fbopFake.NewSimpleClientset()
}
...
func doFake() {
	fbopCS := getFake()

	fakeObj := &v1alpha2.Output{
		TypeMeta: metav1.TypeMeta{
			APIVersion: "logging.kubesphere.io/v1alpha2",
			Kind:       "Output",
		},
		ObjectMeta: metav1.ObjectMeta{
			Name:      "fake-output",
			Namespace: "fake-namespace",
			Labels: map[string]string{
				"foo": "bar",
			},
		},
		Spec: v1alpha2.OutputSpec{
			Alias: "output-alias",
			Match: "applogs.foo",
			Syslog: &fbOutput.Syslog{
				Host: "logs.papertrailapp.com",
				Port: ptrInt32(int32(11111)),
				Mode: "tls",
				TLS: &plugins.TLS{
					Verify: ptrBool(true),
				},
			},
		},
	}

	_, err := fbopCS.FluentbitoperatorV1alpha2().Outputs("fake-namespace").Create(context.Background(), fakeObj, metav1.CreateOptions{})

	if err != nil {
		log.Fatalf("creating output: %v", err)
	}

	fmt.Println("fake object:", fakeObj.Name)

	oobj, err := fbopCS.FluentbitoperatorV1alpha2().Outputs("fake-namespace").Get(context.Background(), "fake-output", metav1.GetOptions{})
	if err != nil {
		log.Fatalf("getting output: %v", err)
	}

	fmt.Printf("oobj:\n%+v\n", oobj)

	fakeList, err := fbopCS.FluentbitoperatorV1alpha2().Outputs("fake-namespace").List(context.Background(), metav1.ListOptions{})
	if err != nil {
		log.Fatalf("Error listing all outputs: %v", err)
	}

	fmt.Printf("fakeList:\n%+v\n", fakeList)
}

doFake()
```

We get error:

```
2021/07/16 11:22:04 Error listing all outputs: no kind "OutputList" is registered for version "fluentbitoperator/v1alpha2" in scheme "pkg/runtime/scheme.go:100"
```
With using the code in this PR we now have to use the new top level API:

```go
_, err := fbopCS.LoggingV1alpha2().Outputs("fake-namespace").Create(context.Background(), fakeObj, metav1.CreateOptions{})
	if err != nil {
		log.Fatalf("creating output: %v", err)
	}
...
fakeList, err := fbopCS.LoggingV1alpha2().Outputs("fake-namespace").List(context.Background(), metav1.ListOptions{})
	if err != nil {
		log.Fatalf("Error listing all outputs: %v", err)
	}
```
and we get the list:
```
fakeList:
&{TypeMeta:{Kind: APIVersion:} ListMeta:{SelfLink: ResourceVersion: Continue: RemainingItemCount:<nil>} Items:[{TypeMeta:{Kind:Output APIVersion:logging.kubesphere.io/v1alpha2} ObjectMeta:{Name:fake-output GenerateName: Namespace:fake-namespace SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[foo:bar] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[]} Spec:{Match:applogs.foo MatchRegex: Alias:output-alias Elasticsearch:<nil> File:<nil> Forward:<nil> HTTP:<nil> Kafka:<nil> Null:<nil> Stdout:<nil> TCP:<nil> Loki:<nil> Syslog:0xc0004a7ba0}}]}
```

This is a breaking change in a sense that all previous calls to `FluentbitoperatorV1alpha2()` will now have to be changed to `LoggingV1alpha2()`, so this should probably go in a new tag and version.

To my understanding this should no effect manifests and CRD's.